### PR TITLE
Refactor key storage + fix COSE verification early abort

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -28,21 +28,9 @@ android {
 	}
 
 	productFlavors {
-		dev {
-			buildConfigField "String", "SIGNING_KEY_KID", '"mmrfzpMU6xc="'
-			buildConfigField "String", "SIGNING_KEY_N", '"AOLmTuP+7Z3md1w+TgIk8qADTqIUGQvg82eGAtAKC5xDvmdz3E4mpQrkSktcx37ozTyNBhhtPQ0VVV3b/rXCjVxQ7f50VNc5VgxhX+P+t5eUSI5FhQ9yRSqkfCJXCY62GMbLbmbNzGst0hkCfpGWnh+RhWTEbxNMGh6jMW38GpL43/KsgVwq2dVrCvlyX+4mGyUtnTtWuR53oMT7kQO2c/IpDu0Ec5kqJ4KjpZHoxGiJBY8e4Cxk1LDqwT2GubHWaopw8Jp47Soudhy1mqzF7PrdTDeHrSKexhO/82q4wTcZNRH4osJfkXXMCdrlcH64M8X79/03pGRfCFMpFdhnrt0="'
-			buildConfigField "String", "SIGNING_KEY_E", '"AQAB"'
-		}
-		abn {
-			buildConfigField "String", "SIGNING_KEY_KID", '"JLxre3vSwyg="'
-			buildConfigField "String", "SIGNING_KEY_N", '"ANG1XnHVRFARGgelLvFbV67VZzdBWvfoQHDtF3Iy4C1QwfPWOPobhjveGPd02ON8fXl0UVnDZXmnAUdDncw6QFDn3VG768NpzUm+ToYShvph27gWiJliqb4pmtAXitBondNSBvLvN0igTmm1N+FlJ+Zt+5j49GKJ6hTso58ghNcK52nhveZYdGQuVglAdgajSOGWUF8AwgguUk5Gt5dNmTQCBzKBy5oKgKlm110ua+NZbbpm0UWlRruO6UlEac8/8AmXqeh55oTbzhP0+ZTc5aJcYHJbSnO1WbXKGZyvSRZE+7ZOBkdh+JpwNZcQBzpCTmhJGcU+ja5ua/DrwNMm7jE="'
-			buildConfigField "String", "SIGNING_KEY_E", '"AQAB"'
-		}
-		prod {
-			buildConfigField "String", "SIGNING_KEY_KID", '"Ll3NP03zOxY="'
-			buildConfigField "String", "SIGNING_KEY_N", '"ALZP+dbLSV1OPEag9pYeCHbMRa45SX5kwqy693EDRF5KxKCNzhFfDZ6LRNUY1ZkK6i009OKMaVpXGzKJV7SQbbt6zoizcEL8lRG4/8UnOik/OE6exgaNT/5JLp2PlZmm+h1Alf6BmWJrHYlD/zp0z1+lsunXpQ4Z64ByA7Yu9/00rBu2ZdVepJu/iiJIwJFQhA5JFA+7n33eBvhgWdAfRdSjk9CHBUDbw5tM5UTlaBhZZj0vA1payx7iHTGwdvNbog43DfpDVLe61Mso+kxYF/VgoBAf+ZkATEWmlytc3g02jZJgtkuyFsYTELDAVycgHWw/QJ0DmXOl0YwWrju4M9M="'
-			buildConfigField "String", "SIGNING_KEY_E", '"AQAB"'
-		}
+		dev {}
+		abn {}
+		prod {}
 	}
 
 	flavorDimensions "version"

--- a/sdk/src/androidTest/java/ch/admin/bag/covidcertificate/eval/chain/VerificationCoseServiceTest.kt
+++ b/sdk/src/androidTest/java/ch/admin/bag/covidcertificate/eval/chain/VerificationCoseServiceTest.kt
@@ -14,7 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.admin.bag.covidcertificate.eval.HC1_A
 import ch.admin.bag.covidcertificate.eval.getInvalidSigningKeys
 import ch.admin.bag.covidcertificate.eval.models.CertType
-import ch.admin.bag.covidcertificate.eval.utils.getHardcodedBagSigningKeys
+import ch.admin.bag.covidcertificate.eval.utils.getHardcodedSigningKeys
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,7 +28,7 @@ class VerificationCoseServiceTest {
 
 	@Test
 	fun decode_success() {
-		val bagKeys = getHardcodedBagSigningKeys()
+		val bagKeys = getHardcodedSigningKeys("dev")
 		val coseService = VerificationCoseService(bagKeys)
 
 		val vr = VerificationResult()
@@ -39,6 +39,20 @@ class VerificationCoseServiceTest {
 		coseService.decode(cose!!, vr, CertType.VACCINATION)
 
 		assertTrue(vr.coseVerified)
+	}
+
+	@Test
+	fun decode_wrongFlavor() {
+		val invalidKeys = getHardcodedSigningKeys("abn")
+		val coseService = VerificationCoseService(invalidKeys)
+
+		val vr = VerificationResult()
+		val encoded = contextIdentifierService.decode(HC1_A, vr)
+		val compressed = base45Service.decode(encoded, vr)
+		val cose = compressorService.decode(compressed, vr)
+		coseService.decode(cose, vr, CertType.VACCINATION)
+
+		assertFalse(vr.coseVerified)
 	}
 
 	@Test

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/Eval.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/Eval.kt
@@ -15,7 +15,7 @@ import ch.admin.bag.covidcertificate.eval.EvalErrorCodes.SIGNATURE_COSE_INVALID
 import ch.admin.bag.covidcertificate.eval.chain.*
 import ch.admin.bag.covidcertificate.eval.models.Bagdgc
 import ch.admin.bag.covidcertificate.eval.nationalrules.NationalRulesVerifier
-import ch.admin.bag.covidcertificate.eval.utils.getHardcodedBagSigningKeys
+import ch.admin.bag.covidcertificate.eval.utils.getHardcodedSigningKeys
 import com.squareup.moshi.Moshi
 
 
@@ -29,6 +29,8 @@ object Eval {
 	private val compressorService = DecompressionService()
 	private val noopCoseService = NoopVerificationCoseService()
 	private val cborService = DefaultCborService()
+
+	private val signingKeys = getHardcodedSigningKeys()
 
 	/**
 	 * @param qrCodeData content of the scanned qr code, of the format "HC1:base45(...)"
@@ -61,8 +63,6 @@ object Eval {
 	 * @return State for the signature check
 	 */
 	suspend fun checkSignature(bagdgc: Bagdgc, context: Context): CheckSignatureState {
-		val keys = getHardcodedBagSigningKeys()
-
 		val vr = bagdgc.verificationResult
 
 		val timestampVerificationService = TimestampVerificationService()
@@ -71,7 +71,7 @@ object Eval {
 			return CheckSignatureState.INVALID(EvalErrorCodes.SIGNATURE_TIMESTAMP_INVALID)
 		}
 
-		val coseService = VerificationCoseService(keys)
+		val coseService = VerificationCoseService(signingKeys)
 		val type = bagdgc.getType() ?: return CheckSignatureState.INVALID(EvalErrorCodes.SIGNATURE_BAGDGC_TYPE_INVALID)
 		coseService.decode(bagdgc.cose, vr, type)
 

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/chain/VerificationCoseService.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/chain/VerificationCoseService.kt
@@ -4,13 +4,11 @@
  */
 package ch.admin.bag.covidcertificate.eval.chain
 
-import COSE.HeaderKeys
 import COSE.MessageTag
 import COSE.OneKey
 import COSE.Sign1Message
 import ch.admin.bag.covidcertificate.eval.models.CertType
 import ch.admin.bag.covidcertificate.eval.models.Jwk
-import ch.admin.bag.covidcertificate.eval.utils.toBase64
 
 class VerificationCoseService(private val keys: List<Jwk>) {
 	private val TAG = VerificationCoseService::class.java.simpleName
@@ -18,29 +16,27 @@ class VerificationCoseService(private val keys: List<Jwk>) {
 	fun decode(input: ByteArray, verificationResult: VerificationResult, type: CertType): ByteArray {
 		verificationResult.coseVerified = false
 
-		return try {
-			(Sign1Message.DecodeFromBytes(input, MessageTag.Sign1) as Sign1Message).also { signature ->
-				try {
-					keys
-						// "use": keys could be valid for signing a vaccination, but not a test certificate.
-						.filter { k -> k.isAllowedToSign(type) }
-						.filter { k -> k.getPublicKey() != null }
-						.forEach { k ->
-							val pubKey = OneKey(k.getPublicKey(), null)
-							if (signature.validate(pubKey)) {
-								verificationResult.coseVerified = true
-								return signature.GetContent()
-							}
-						}
-				} catch (e: Throwable) {
-					e.printStackTrace()
-					signature.GetContent()
-				}
-			}.GetContent()
+		val signature: Sign1Message = try {
+			(Sign1Message.DecodeFromBytes(input, MessageTag.Sign1) as Sign1Message)
 		} catch (e: Throwable) {
-			e.printStackTrace()
-			input
+			null
+		} ?: return input
+
+		for (k in keys) {
+			val pk = k.getPublicKey() ?: continue
+
+			try {
+				val pubKey = OneKey(pk, null)
+				if (signature.validate(pubKey)) {
+					verificationResult.coseVerified = true
+					return signature.GetContent()
+				}
+			} catch (e: Throwable) {
+				e.printStackTrace()
+			}
 		}
+
+		return input
 	}
 
 }

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/models/Jwk.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/models/Jwk.kt
@@ -55,6 +55,15 @@ data class Jwk(
 			n = n,
 			e = e,
 		)
+
+		fun fromXY(kid: String, x: String, y: String, use: String) = Jwk(
+			kid = kid,
+			kty = "EC",
+			alg = "ES256",
+			use = use,
+			x = x,
+			y = y,
+		)
 	}
 
 	fun getKid(): ByteArray = kid.fromBase64()
@@ -73,6 +82,7 @@ data class Jwk(
 			// Can throw e.g. if the (x, y) pair is not a point on the curve
 			e.printStackTrace()
 		}
+		Log.w(TAG, "Failed to create PublicKey for kid $kid")
 		return null
 	}
 

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/utils/SigningKeyUtil.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/utils/SigningKeyUtil.kt
@@ -13,12 +13,32 @@ package ch.admin.bag.covidcertificate.eval.utils
 import ch.admin.bag.covidcertificate.eval.models.Jwk
 import ch.admin.bag.covidcertificate.verifier.eval.BuildConfig
 
-internal fun getHardcodedBagSigningKeys(): List<Jwk> {
-	val kid = BuildConfig.SIGNING_KEY_KID
-	val n = BuildConfig.SIGNING_KEY_N
-	val e = BuildConfig.SIGNING_KEY_E
 
-	return listOf(
-		Jwk.fromNE(kid, n, e, use = "")
-	)
+internal fun getHardcodedSigningKeys(flavor: String = BuildConfig.FLAVOR): List<Jwk> {
+	val jwks = mutableListOf<Jwk>()
+	when (flavor) {
+		"dev" -> {
+			jwks.add(Jwk.fromNE(CH_DEV_KID, CH_DEV_N, CH_DEV_E, use = ""))
+		}
+		"abn" -> {
+			jwks.add(Jwk.fromNE(CH_ABN_KID, CH_ABN_N, CH_ABN_E, use = ""))
+		}
+		else -> {
+			jwks.add(Jwk.fromNE(CH_PROD_KID, CH_PROD_N, CH_PROD_E, use = ""))
+		}
+	}
+	return jwks
 }
+
+/* Switzerland's public keys */
+private const val CH_DEV_KID = "mmrfzpMU6xc="
+private const val CH_DEV_N = "AOLmTuP+7Z3md1w+TgIk8qADTqIUGQvg82eGAtAKC5xDvmdz3E4mpQrkSktcx37ozTyNBhhtPQ0VVV3b/rXCjVxQ7f50VNc5VgxhX+P+t5eUSI5FhQ9yRSqkfCJXCY62GMbLbmbNzGst0hkCfpGWnh+RhWTEbxNMGh6jMW38GpL43/KsgVwq2dVrCvlyX+4mGyUtnTtWuR53oMT7kQO2c/IpDu0Ec5kqJ4KjpZHoxGiJBY8e4Cxk1LDqwT2GubHWaopw8Jp47Soudhy1mqzF7PrdTDeHrSKexhO/82q4wTcZNRH4osJfkXXMCdrlcH64M8X79/03pGRfCFMpFdhnrt0="
+private const val CH_DEV_E = "AQAB"
+
+private const val CH_ABN_KID = "JLxre3vSwyg="
+private const val CH_ABN_N = "ANG1XnHVRFARGgelLvFbV67VZzdBWvfoQHDtF3Iy4C1QwfPWOPobhjveGPd02ON8fXl0UVnDZXmnAUdDncw6QFDn3VG768NpzUm+ToYShvph27gWiJliqb4pmtAXitBondNSBvLvN0igTmm1N+FlJ+Zt+5j49GKJ6hTso58ghNcK52nhveZYdGQuVglAdgajSOGWUF8AwgguUk5Gt5dNmTQCBzKBy5oKgKlm110ua+NZbbpm0UWlRruO6UlEac8/8AmXqeh55oTbzhP0+ZTc5aJcYHJbSnO1WbXKGZyvSRZE+7ZOBkdh+JpwNZcQBzpCTmhJGcU+ja5ua/DrwNMm7jE="
+private const val CH_ABN_E = "AQAB"
+
+private const val CH_PROD_KID = "Ll3NP03zOxY="
+private const val CH_PROD_N = "ALZP+dbLSV1OPEag9pYeCHbMRa45SX5kwqy693EDRF5KxKCNzhFfDZ6LRNUY1ZkK6i009OKMaVpXGzKJV7SQbbt6zoizcEL8lRG4/8UnOik/OE6exgaNT/5JLp2PlZmm+h1Alf6BmWJrHYlD/zp0z1+lsunXpQ4Z64ByA7Yu9/00rBu2ZdVepJu/iiJIwJFQhA5JFA+7n33eBvhgWdAfRdSjk9CHBUDbw5tM5UTlaBhZZj0vA1payx7iHTGwdvNbog43DfpDVLe61Mso+kxYF/VgoBAf+ZkATEWmlytc3g02jZJgtkuyFsYTELDAVycgHWw/QJ0DmXOl0YwWrju4M9M="
+private const val CH_PROD_E = "AQAB"


### PR DESCRIPTION
Refactor the signing key storage. The initial motivation was preparing for bringing in Liechtenstein's keys easily when they're ready.

Bugfix: When checking the signature of one key would throw an exception, other keys in the list would not be tried anymore.