### PR TITLE
Validate x509 Chain

### DIFF
--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
@@ -46,7 +46,7 @@ val APPLICATION_JSON = "application/json".toMediaType()
  */
  class JwsInterceptor(rootCA: X509Certificate) :
         Interceptor {
-    val keyResolver: JwsKeyResolver = JwsKeyResolver(rootCA)
+    private val keyResolver: JwsKeyResolver = JwsKeyResolver(rootCA)
 
     @Throws(IOException::class)
 
@@ -58,7 +58,7 @@ val APPLICATION_JSON = "application/json".toMediaType()
         if (response.cacheResponse != null) {
             return response
         }
-        val jws = response.body!!.string()
+        val jws = response.body?.string() ?: throw SignatureException("Body has no signature")
 
         var body = ""
         try {
@@ -73,6 +73,7 @@ val APPLICATION_JSON = "application/json".toMediaType()
         } catch (o: ExpiredJwtException) {
             throw SignatureException("Expired JWT")
         }
+
         // SAFE ZONE
         // from here on body contains a JSON-string of the payload of the JWS, whose signature we verified.
 

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
@@ -10,12 +10,14 @@
 
 package ch.admin.bag.covidcertificate.eval.net
 
+import android.util.Base64
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import okhttp3.Interceptor
 
@@ -23,10 +25,15 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
 
 import okhttp3.ResponseBody.Companion.toResponseBody
+import java.io.ByteArrayInputStream
 import java.io.IOException
+import java.lang.Exception
 import java.security.PublicKey
 
 import java.security.SignatureException
+import java.security.cert.Certificate
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 
 /// application/json media type for the payload of a JWS
 val APPLICATION_JSON = "application/json".toMediaType()
@@ -37,8 +44,10 @@ val APPLICATION_JSON = "application/json".toMediaType()
    is `application/json`.
  The signature of the JWS is verified with `publicKey`.
  */
- class JwsInterceptor(private val publicKey: PublicKey) :
+ class JwsInterceptor(rootCA: X509Certificate) :
         Interceptor {
+    val keyResolver: JwsKeyResolver = JwsKeyResolver(rootCA)
+
     @Throws(IOException::class)
 
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -54,7 +63,7 @@ val APPLICATION_JSON = "application/json".toMediaType()
         var body = ""
         try {
             val claimsJws : Jws<Claims> = Jwts.parserBuilder()
-                    .setSigningKey(publicKey)
+                .setSigningKeyResolver(keyResolver)
                     .build()
                     .parseClaimsJws(jws)
             // now that the JWS is verified, we can safely assume that the body can be trusted, so serialize it to JSON again

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsKeyResolver.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsKeyResolver.kt
@@ -22,17 +22,21 @@ import java.security.cert.X509Certificate
         for ( cert in encodedCertificates) {
             val certBytes = Base64.decode(cert, Base64.DEFAULT)
             val byteInputStream = ByteArrayInputStream(certBytes)
-            val x509 = certificateFactory.generateCertificate(byteInputStream) as X509Certificate
-            if (certificates.isNotEmpty()) {
-                val certificateToVerify = certificates.last()
-                try {
-                    certificateToVerify.verify(x509.publicKey)
+            // catch exception and rethrow
+            try {
+                val x509 = certificateFactory.generateCertificate(byteInputStream) as X509Certificate
+                if (certificates.isNotEmpty()) {
+                    val certificateToVerify = certificates.last()
+                    try {
+                        certificateToVerify.verify(x509.publicKey)
+                    } catch (e: Exception) {
+                        throw SignatureException("Certificate chain cannot be verified")
+                    }
                 }
-                catch (e: Exception) {
-                    throw SignatureException("Certificate chain cannot be verified")
-                }
+                certificates.add(x509)
+            } catch (e: Exception) {
+                throw SignatureException("x5c is not a x509 certificate")
             }
-            certificates.add(x509)
         }
 
         val checkWithRoot = certificates.last()

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsKeyResolver.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsKeyResolver.kt
@@ -1,0 +1,47 @@
+package ch.admin.bag.covidcertificate.eval.net
+
+import android.util.Base64
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.JwsHeader
+import io.jsonwebtoken.SigningKeyResolverAdapter
+import java.io.ByteArrayInputStream
+import java.lang.Exception
+import java.security.Key
+import io.jsonwebtoken.security.SignatureException
+import java.security.cert.CertificateFactory
+
+import java.security.cert.X509Certificate
+
+ class JwsKeyResolver(private val rootCA: X509Certificate) : SigningKeyResolverAdapter() {
+
+    override fun resolveSigningKey(jwsHeader: JwsHeader<*>, claims: Claims) : Key
+     {
+         val encodedCertificates : List<String> = jwsHeader["x5c"] as List<String>? ?: throw SignatureException("JWS is missing the required certificate chain")
+        var certificates : MutableList<X509Certificate> = mutableListOf()
+        val certificateFactory = CertificateFactory.getInstance("X.509")
+        for ( cert in encodedCertificates) {
+            val certBytes = Base64.decode(cert, Base64.DEFAULT)
+            val byteInputStream = ByteArrayInputStream(certBytes)
+            val x509 = certificateFactory.generateCertificate(byteInputStream) as X509Certificate
+            if (certificates.isNotEmpty()) {
+                val certificateToVerify = certificates.last()
+                try {
+                    certificateToVerify.verify(x509.publicKey)
+                }
+                catch (e: Exception) {
+                    throw SignatureException("Certificate chain cannot be verified")
+                }
+            }
+            certificates.add(x509)
+        }
+
+        val checkWithRoot = certificates.last()
+         try {
+             checkWithRoot.verify(rootCA.publicKey)
+         } catch (e: Exception) {
+             throw SignatureException("Certificate chain cannot be verified")
+         }
+
+         return certificates[0].publicKey
+     }
+ }


### PR DESCRIPTION
# DRAFT PR
This is an initial draft for the android Interceptor. Please review and discuss before merging

# What does it do
Since we don't want to hard code the signing key in the app, we use a x509 chain validation. We use a specified root certificate to validate the last certificate sent in the certificate chain of the `JWS`.

