### PR TITLE
Add CN pinning

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -29,12 +29,15 @@ android {
 	productFlavors {
 		dev {
 			buildConfigField "String", "BASE_URL_TRUST_LIST", '"https://www.cc-d.bit.admin.ch/trust/v1/"'
+			buildConfigField "String", "LEAF_CERT_CN", '"CH01-AppContentCertificate-ref"'
 		}
 		abn {
 			buildConfigField "String", "BASE_URL_TRUST_LIST", '"https://www.cc-a.bit.admin.ch/trust/v1/"'
+			buildConfigField "String", "LEAF_CERT_CN", '"CH01-AppContentCertificate-abn"'
 		}
 		prod {
 			buildConfigField "String", "BASE_URL_TRUST_LIST", '"https://www.cc.bit.admin.ch/trust/v1/"'
+			buildConfigField "String", "LEAF_CERT_CN", '"CH01-AppContentCertificate"'
 		}
 	}
 
@@ -74,12 +77,12 @@ dependencies {
 	api 'com.squareup.moshi:moshi-adapters:1.11.0'
 	kapt "com.squareup.moshi:moshi-kotlin-codegen:1.11.0"
 
-	//JWS Library
+	// JWS
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-	api 'io.jsonwebtoken:jjwt-impl:0.11.2',
-			'io.jsonwebtoken:jjwt-jackson:0.11.2'
+	api 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	api 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
-	//jackson for natinoal rules
+	// National rules
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
 
 	testImplementation 'junit:junit:4.+'

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/CovidCertificateSdk.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/CovidCertificateSdk.kt
@@ -96,6 +96,8 @@ object CovidCertificateSdk {
 		return certificateFactory.generateCertificate(inputStream) as X509Certificate
 	}
 
+	fun getExpectedCommonName() = BuildConfig.LEAF_CERT_CN
+
 	private fun requireInitialized() {
 		if (!isInitialized) {
 			throw IllegalStateException("CovidCertificateSdk must be initialized by calling init(context)")
@@ -104,9 +106,10 @@ object CovidCertificateSdk {
 
 	private fun createRetrofit(context: Context): Retrofit {
 		val rootCa = getRootCa(context)
+		val expectedCommonName = getExpectedCommonName()
 		val okHttpBuilder = OkHttpClient.Builder()
 			.certificatePinner(CertificatePinning.pinner)
-			.addInterceptor(JwsInterceptor(rootCa))
+			.addInterceptor(JwsInterceptor(rootCa, expectedCommonName))
 			.addInterceptor(ApiKeyInterceptor())
 			.addInterceptor(UserAgentInterceptor(Config.userAgent))
 

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsKeyResolver.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsKeyResolver.kt
@@ -3,49 +3,80 @@ package ch.admin.bag.covidcertificate.eval.net
 import android.util.Base64
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.JwsHeader
+import io.jsonwebtoken.JwsHeader.X509_CERT_CHAIN
 import io.jsonwebtoken.SigningKeyResolverAdapter
-import java.io.ByteArrayInputStream
-import java.lang.Exception
-import java.security.Key
 import io.jsonwebtoken.security.SignatureException
+import java.io.ByteArrayInputStream
+import java.security.Key
 import java.security.cert.CertificateFactory
-
 import java.security.cert.X509Certificate
 
- class JwsKeyResolver(private val rootCA: X509Certificate) : SigningKeyResolverAdapter() {
+class JwsKeyResolver(
+	private val rootCA: X509Certificate,
+	private val expectedCommonName: String,
+) : SigningKeyResolverAdapter() {
 
-    override fun resolveSigningKey(jwsHeader: JwsHeader<*>, claims: Claims) : Key
-     {
-         val encodedCertificates : List<String> = jwsHeader["x5c"] as List<String>? ?: throw SignatureException("JWS is missing the required certificate chain")
-        var certificates : MutableList<X509Certificate> = mutableListOf()
-        val certificateFactory = CertificateFactory.getInstance("X.509")
-        for ( cert in encodedCertificates) {
-            val certBytes = Base64.decode(cert, Base64.DEFAULT)
-            val byteInputStream = ByteArrayInputStream(certBytes)
-            // catch exception and rethrow
-            try {
-                val x509 = certificateFactory.generateCertificate(byteInputStream) as X509Certificate
-                if (certificates.isNotEmpty()) {
-                    val certificateToVerify = certificates.last()
-                    try {
-                        certificateToVerify.verify(x509.publicKey)
-                    } catch (e: Exception) {
-                        throw SignatureException("Certificate chain cannot be verified")
-                    }
-                }
-                certificates.add(x509)
-            } catch (e: Exception) {
-                throw SignatureException("x5c is not a x509 certificate")
-            }
-        }
+	/**
+	 * Parses and verifies the certificate chain in the JwsHeader.
+	 * Upon success, returns the public key with which the JWS is signed.
+	 */
+	override fun resolveSigningKey(jwsHeader: JwsHeader<*>, claims: Claims): Key {
+		val encodedCertificates: List<String> = jwsHeader[X509_CERT_CHAIN] as? List<String>?
+			?: throw SignatureException("JWS is missing the required certificate chain")
+		val certificates: MutableList<X509Certificate> = mutableListOf()
+		val certificateFactory = CertificateFactory.getInstance("X.509")
 
-        val checkWithRoot = certificates.last()
-         try {
-             checkWithRoot.verify(rootCA.publicKey)
-         } catch (e: Exception) {
-             throw SignatureException("Certificate chain cannot be verified")
-         }
+		// Check the certificate chain: each cert is certified by the next cert in the chain (i.e. the root CA comes last)
+		for (cert in encodedCertificates) {
+			val certBytes = Base64.decode(cert, Base64.DEFAULT)
+			val byteInputStream = ByteArrayInputStream(certBytes)
 
-         return certificates[0].publicKey
-     }
- }
+			// catch exceptions and rethrow
+			try {
+				val currentCert = certificateFactory.generateCertificate(byteInputStream) as X509Certificate
+				if (certificates.isNotEmpty()) {
+					val previousCert = certificates.last()
+					try {
+						// Is the previous cert signed by the current cert?
+						previousCert.verify(currentCert.publicKey)
+					} catch (e: Exception) {
+						throw SignatureException("Certificate chain cannot be verified")
+					}
+				}
+				certificates.add(currentCert)
+			} catch (e: Exception) {
+				throw SignatureException("x5c is not a x509 certificate")
+			}
+		}
+
+		if (certificates.isEmpty()) {
+			throw SignatureException("Empty parsed certificate chain")
+		}
+
+		// Is the end of the chain signed by the given root CA?
+		val checkWithRoot = certificates.last()
+		try {
+			checkWithRoot.verify(rootCA.publicKey)
+		} catch (e: Exception) {
+			throw SignatureException("Certificate chain cannot be verified")
+		}
+
+		val signingCertificate = certificates.first()
+
+		// Extract Common Name
+		val subjectName = signingCertificate.subjectX500Principal.name
+		val startIndex = maxOf(0, subjectName.indexOf("CN="))
+		var endIndex = subjectName.indexOf(",", startIndex)
+		if (endIndex < startIndex) {
+			endIndex = subjectName.length
+		}
+
+		// Check that signing cert belongs to the correct environment
+		val commonName = subjectName.substring(startIndex + 3, endIndex)
+		if (commonName != expectedCommonName) {
+			throw SignatureException("Wrong CN! Got $commonName but expected $expectedCommonName")
+		}
+
+		return signingCertificate.publicKey
+	}
+}


### PR DESCRIPTION
Add pinning of the common name to separate the different environments.

Notes:
- Tested only on DEV. On ABN and PROD I keep getting different 40Xs (no matter how I play around with the API keys), will have to test that on Monday maybe?
- Changes the JwsInterceptor to throw IOExceptions rather than java.security.SignatureExceptions - the former are caught at some point, the latter would crash the app.
- Formats JwsKeyResolver with our code style, hence the larger diff.