### PR TITLE
Rename api key to app token

### DIFF
--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/data/Config.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/data/Config.kt
@@ -13,6 +13,6 @@ package ch.admin.bag.covidcertificate.eval.data
 import ch.admin.bag.covidcertificate.eval.net.UserAgentInterceptor
 
 object Config {
-	var apiKey: String = ""
+	var appToken: String = ""
 	var userAgent: UserAgentInterceptor.UserAgentGenerator = UserAgentInterceptor.UserAgentGenerator { "covid-cert-sdk" }
 }

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/ApiKeyInterceptor.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/ApiKeyInterceptor.kt
@@ -18,13 +18,13 @@ class ApiKeyInterceptor : Interceptor {
 
 	companion object {
 		private const val HEADER_AUTHORIZATION = "Authorization"
-		private const val API_KEY_PREFIX = "Bearer "
+		private const val APP_TOKEN_PREFIX = "Bearer "
 	}
 
 	override fun intercept(chain: Interceptor.Chain): Response {
 		val newRequest = chain.request()
 			.newBuilder()
-			.addHeader(HEADER_AUTHORIZATION, API_KEY_PREFIX + Config.apiKey)
+			.addHeader(HEADER_AUTHORIZATION, APP_TOKEN_PREFIX + Config.appToken)
 			.build()
 
 		return chain.proceed(newRequest)

--- a/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
+++ b/sdk/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
@@ -13,7 +13,6 @@ package ch.admin.bag.covidcertificate.eval.net
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import io.jsonwebtoken.Claims
-import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
 import okhttp3.Interceptor
@@ -56,10 +55,9 @@ class JwsInterceptor(
 			body = Moshi.Builder().build()
 				.adapter<Claims>(Types.newParameterizedType(Map::class.java, String::class.java, Object::class.java))
 				.toJson(claimsJws.body)
-		} catch (e: io.jsonwebtoken.security.SignatureException) {
-			throw IOException("Invalid Signature")
-		} catch (o: ExpiredJwtException) {
-			throw IOException("Expired JWT")
+		} catch (e: Throwable) {
+			e.printStackTrace()
+			throw IOException("Failed to parse/verify JWS")
 		}
 
 		// SAFE ZONE


### PR DESCRIPTION
To better represent what it does.

While testing the app crashed since the JWS parsing threw an uncaught exception:
`io.jsonwebtoken.MalformedJwtException: JWT strings must contain exactly 2 period characters. Found: 0`
So while I was at it anyway, we now catch all exceptions just to be sure.
