### PR TITLE
Use binary gradle distribution sha256 hash instead of wrapper hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Introduction
 
 This is the implementation of
-the [Electronic Health Certificates (EHN)](https://github.com/ehn-digital-green-development/hcert-spec)
+the [Electronic Health Certificates (HCERT)](https://github.com/ehn-digital-green-development/hcert-spec)
 and [Swiss Certificate Light](https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/covid-zertifikat.html#-518758716)
 specification used to verify the validity of COVID
 Certificates [in Switzerland](https://github.com/admin-ch/CovidCertificate-App-Android).

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637
+distributionSha256Sum=765442b8069c6bee2ea70713861c027587591c6b1df2c857a23361512560894e
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
See the [Gradle release checksums](https://gradle.org/release-checksums/) page